### PR TITLE
Fix GitHub-Actions CI workflow and use newer Emacs versions there

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,13 +16,15 @@ jobs:
         emacs_version:
           - '26.3'
           - '27.1'
+          - '28.2'
+          - '29.1'
           - 'snapshot'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Emacs
-        uses: purcell/setup-emacs@v3.0
+        uses: purcell/setup-emacs@master
         with:
           version: ${{ matrix.emacs_version }}
 

--- a/compiler-explorer-test.el
+++ b/compiler-explorer-test.el
@@ -38,7 +38,7 @@
 
 (defun compiler-explorer-test--wait ()
   "Wait until compilation finishes."
-  (with-timeout (5 (error "Test timed out"))
+  (with-timeout (15 (error "Test timed out"))
     (while (or (member compiler-explorer--recompile-timer timer-list)
                (not (request-response-done-p
                      compiler-explorer--last-compilation-request))


### PR DESCRIPTION
* .github/workflows/tests.yml: Update to use newer versions.
* compiler-explorer-test.el (compiler-explorer-test--wait): Increase timeout.